### PR TITLE
Added UIControlEventValueChanged

### DIFF
--- a/Control/PPiFlatSegmentedControl.m
+++ b/Control/PPiFlatSegmentedControl.m
@@ -130,6 +130,8 @@
         if(self.selBlock) {
             self.selBlock(selectedIndex);
         }
+        // Also fire a ValueChanged Event
+        [self sendActionsForControlEvents:UIControlEventValueChanged];
     }
 }
 


### PR DESCRIPTION
When a segment is selected, a UIControlEventValueChanged event is fired. This is convenient when the segmented control is created in Interface Builder without the custom init method which is the only way to set the selBlock. 